### PR TITLE
Make pry dumber

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,8 @@
+Pry.config.print = proc do |output, value, _pry_|
+  case value
+  when ActiveRecord::Relation
+    output.puts "=> #{value.to_s}"
+  else
+    Pry::DEFAULT_PRINT.call(output, value, _pry_)
+  end
+end

--- a/bin/setup
+++ b/bin/setup
@@ -35,5 +35,5 @@ chdir APP_ROOT do
   # Add necessary setup steps to this file.
   system "git init"
   system "git add -A"
-  system "git commit -m `Initial commit'"
+  system "git commit -m 'Initial commit'"
 end


### PR DESCRIPTION
We are failing to explain the difference between a collection and a record properly, leading to millions of questions [like this](https://piazza.com/class/jxc5bt9wqba28c?cid=36); even from students with software development experience.

This patch adds a `.pryrc` configuration file that overrides the default representation of `ActiveRecord::Relation` to make it dumber/less informative/hopefully clearer to students. It will only display `Array of 323 Photo`, and force them to use `at` to go further.